### PR TITLE
Add WebXR support and export target for WebXR

### DIFF
--- a/.github/workflows/build-on-push.yaml
+++ b/.github/workflows/build-on-push.yaml
@@ -60,6 +60,14 @@ jobs:
             export-args: --install-android-build-template
             export-folder: build/magicleap
 
+          # Export for WebXR
+          - name: 🌐 WebXR
+            os: ubuntu-22.04
+            platform: web
+            export-preset: WebXR
+            export-type: release
+            export-folder: build/webxr
+
     steps:
       # Check out the repository
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This now uses Github matrix-builds and:
   - Meta Quest
   - Pico
   - Magic Leap
+  - WebXR
 - Publish Artifacts (if making Github Release)
 
 Additional exports may be added by appending to the matrix rules.

--- a/build/webxr/.gitignore
+++ b/build/webxr/.gitignore
@@ -1,0 +1,2 @@
+*.*
+!.gitignore

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -819,3 +819,52 @@ pico_xr_features/face_tracking=0
 pico_xr_features/hand_tracking=0
 xr_features/enable_magicleap_plugin=true
 magicleap_xr_features/hand_tracking=0
+
+[preset.5]
+
+name="WebXR"
+platform="Web"
+runnable=true
+advanced_options=true
+dedicated_server=false
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+export_path="build/webxr/index.html"
+encryption_include_filters=""
+encryption_exclude_filters=""
+encrypt_pck=false
+encrypt_directory=false
+script_export_mode=2
+
+[preset.5.options]
+
+custom_template/debug=""
+custom_template/release=""
+variant/extensions_support=false
+variant/thread_support=false
+vram_texture_compression/for_desktop=true
+vram_texture_compression/for_mobile=false
+html/export_icon=true
+html/custom_html_shell=""
+html/head_include="<script src=\"https://cdn.jsdelivr.net/npm/webxr-polyfill@latest/build/webxr-polyfill.js\"></script>
+<script>
+var polyfill = new WebXRPolyfill();
+</script>
+<script src=\"https://cdn.jsdelivr.net/npm/webxr-layers-polyfill@latest/build/webxr-layers-polyfill.js\"></script>
+<script>
+var layersPolyfill = new WebXRLayersPolyfill();
+</script>"
+html/canvas_resize_policy=2
+html/focus_canvas_on_start=true
+html/experimental_virtual_keyboard=false
+progressive_web_app/enabled=false
+progressive_web_app/ensure_cross_origin_isolation_headers=true
+progressive_web_app/offline_page=""
+progressive_web_app/display=1
+progressive_web_app/orientation=0
+progressive_web_app/icon_144x144=""
+progressive_web_app/icon_180x180=""
+progressive_web_app/icon_512x512=""
+progressive_web_app/background_color=Color(0, 0, 0, 1)

--- a/main.tscn
+++ b/main.tscn
@@ -1,23 +1,6 @@
 [gd_scene load_steps=7 format=3 uid="uid://conll6q8h2o1l"]
 
-[sub_resource type="GDScript" id="GDScript_kpg5k"]
-script/source = "extends Node3D
-
-var xr_interface: XRInterface
-
-func _ready():
-	xr_interface = XRServer.find_interface(\"OpenXR\")
-	if xr_interface and xr_interface.is_initialized():
-		print(\"OpenXR initialized successfully\")
-
-		# Turn off v-sync!
-		DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_DISABLED)
-
-		# Change our main viewport to output to the HMD
-		get_viewport().use_xr = true
-	else:
-		print(\"OpenXR not initialized, please check if your headset is connected\")
-"
+[ext_resource type="PackedScene" uid="uid://bm7iv0a7s63dc" path="res://start_xr.tscn" id="1_kaaya"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_r1hn3"]
 sky_horizon_color = Color(0.64625, 0.65575, 0.67075, 1)
@@ -38,7 +21,6 @@ size = Vector3(0.1, 0.1, 0.1)
 size = Vector3(0.1, 0.1, 0.1)
 
 [node name="Main" type="Node3D"]
-script = SubResource("GDScript_kpg5k")
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="."]
 environment = SubResource("Environment_bp8ld")
@@ -67,3 +49,5 @@ pose = &"aim"
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="XROrigin3D/RightController3D"]
 mesh = SubResource("BoxMesh_2tjn8")
+
+[node name="StartXR" parent="." instance=ExtResource("1_kaaya")]

--- a/start_xr.gd
+++ b/start_xr.gd
@@ -1,0 +1,162 @@
+extends Node
+
+
+# Current XR interface
+var _xr_interface : XRInterface
+
+# Is a WebXR is_session_supported query running
+var _webxr_session_query : bool = false
+
+# XR active flag
+var _xr_active : bool = false
+
+
+# Initialize XR when ready
+func _ready() -> void:
+	if !Engine.is_editor_hint():
+		_initialize()
+
+
+# Initialize the XR interface
+func _initialize() -> void:
+	# Check for OpenXR interface
+	_xr_interface = XRServer.find_interface('OpenXR')
+	if _xr_interface:
+		_initialize_openxr()
+		return
+
+	# Check for WebXR interface
+	_xr_interface = XRServer.find_interface('WebXR')
+	if _xr_interface:
+		_initialize_webxr()
+		return
+
+	# No XR interface
+	print("No XR interface detected")
+
+
+# Initialize OpenXR interface
+func _initialize_openxr() -> void:
+	print("OpenXR: Initializing")
+
+	# Initialize the OpenXR interface
+	if not _xr_interface.is_initialized():
+		print("OpenXR: Initializing interface")
+		if not _xr_interface.initialize():
+			push_error("OpenXR: Failed to initialize")
+			return
+
+	# Connect the OpenXR events
+	_xr_interface.connect("session_begun", _on_openxr_session_begun)
+	_xr_interface.connect("session_visible", _on_openxr_visible_state)
+	_xr_interface.connect("session_focussed", _on_openxr_focused_state)
+
+	# Disable vsync and switch to XR mode
+	DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_DISABLED)
+	get_viewport().use_xr = true
+
+
+# Initialize WebXR interface
+func _initialize_webxr() -> void:
+	print("WebXR: Initializing")
+
+	# Connect the WebXR events
+	_xr_interface.connect("session_supported", _on_webxr_session_supported)
+	_xr_interface.connect("session_started", _on_webxr_session_started)
+	_xr_interface.connect("session_ended", _on_webxr_session_ended)
+	_xr_interface.connect("session_failed", _on_webxr_session_failed)
+
+	# Skip if already active
+	if get_viewport().use_xr:
+		return
+
+	# Query for WebXR immersive session - delivered to _webxr_session_supported
+	_webxr_session_query = true
+	_xr_interface.is_session_supported('immersive-vr')
+
+
+# Handle OpenXR session ready
+func _on_openxr_session_begun() -> void:
+	print("OpenXR: Session begun")
+
+
+# Handle OpenXR visible state
+func _on_openxr_visible_state() -> void:
+	# Report the XR ending
+	if _xr_active:
+		print("OpenXR: XR ended (visible_state)")
+		_xr_active = false
+
+
+# Handle OpenXR focused state
+func _on_openxr_focused_state() -> void:
+	# Report the XR starting
+	if not _xr_active:
+		print("OpenXR: XR started (focused_state)")
+		_xr_active = true
+
+
+# Handle WebXR session supported check
+func _on_webxr_session_supported(session_mode: String, supported: bool) -> void:
+	# Skip if not running session-query
+	if not _webxr_session_query:
+		return
+
+	# Clear the query flag
+	_webxr_session_query = false
+
+	# Report if not supported
+	if not supported:
+		OS.alert("Your web browser doesn't support " + session_mode + ". Sorry!")
+		return
+
+	# WebXR supported - show canvas on web browser to enter WebVR
+	$EnterWebXR.visible = true
+
+
+# Handle the Enter VR button on the WebXR browser
+func _on_enter_webxr_button_pressed() -> void:
+	# Configure the WebXR interface
+	_xr_interface.session_mode = 'immersive-vr'
+	_xr_interface.requested_reference_space_types = 'bounded-floor, local-floor, local'
+	_xr_interface.required_features = 'local-floor'
+	_xr_interface.optional_features = 'bounded-floor'
+
+	# Add hand-tracking if enabled in the project settings
+	if ProjectSettings.get_setting_with_override("xr/openxr/extensions/hand_tracking"):
+		_xr_interface.optional_features += ", hand-tracking"
+
+	# Initialize the interface. This should trigger either _on_webxr_session_started
+	# or _on_webxr_session_failed
+	if not _xr_interface.initialize():
+		OS.alert("Failed to initialize WebXR")
+
+
+# Called when the WebXR session has started successfully
+func _on_webxr_session_started() -> void:
+	print("WebXR: Session started")
+
+	# Hide the canvas and switch the viewport to XR
+	$EnterWebXR.visible = false
+	get_viewport().use_xr = true
+
+	# Report the XR starting
+	_xr_active = true
+
+
+# Called when the user ends the immersive VR session
+func _on_webxr_session_ended() -> void:
+	print("WebXR: Session ended")
+
+	# Show the canvas and switch the viewport to non-XR
+	$EnterWebXR.visible = true
+	get_viewport().use_xr = false
+
+	# Report the XR ending
+	_xr_active = false
+
+
+# Called when the immersive VR session fails to start
+func _on_webxr_session_failed(message: String) -> void:
+	OS.alert("Unable to enter VR: " + message)
+	$EnterWebXR.visible = true

--- a/start_xr.tscn
+++ b/start_xr.tscn
@@ -1,0 +1,25 @@
+[gd_scene load_steps=2 format=3 uid="uid://bm7iv0a7s63dc"]
+
+[ext_resource type="Script" path="res://start_xr.gd" id="1_g4euo"]
+
+[node name="StartXR" type="Node"]
+script = ExtResource("1_g4euo")
+
+[node name="EnterWebXR" type="CanvasLayer" parent="."]
+visible = false
+
+[node name="EnterVRButton" type="Button" parent="EnterWebXR"]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -100.0
+offset_top = -30.0
+offset_right = 100.0
+offset_bottom = 30.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "Enter VR"
+
+[connection signal="pressed" from="EnterWebXR/EnterVRButton" to="." method="_on_enter_webxr_button_pressed"]


### PR DESCRIPTION
This PR adds WebXR support by:
- Moving "start-xr" logic to a separate node supporting OpenXR and WebXR
- Adding a WebXR export preset
- Add example WebXR publish